### PR TITLE
Better way to unset a style cross browser

### DIFF
--- a/index.js
+++ b/index.js
@@ -520,7 +520,7 @@ WuiDom.prototype.setStyles = function (map) {
  * @param {String} property
  */
 WuiDom.prototype.unsetStyle = function (property) {
-	this.rootElement.style[property] = null;
+	this.rootElement.style[property] = '';
 };
 
 /**


### PR DESCRIPTION
It seems IE doesn't do anything when trying to set to `null` or `undefined`
