### PR TITLE
bugfix: getClassName function fail if rootElement is not defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -606,7 +606,7 @@ function removeClassNames(baseList, args) {
  */
 WuiDom.prototype.getClassNames = function () {
 	// returns an array of all class names
-
+	if (!this.rootElement) return [];
 	return parseClassNames(this.rootElement.className);
 };
 


### PR DESCRIPTION
Got this problem: If a non initialised `wuiDom` try to call `getClassNames` then an exception is thrown.

Fix: we check if `rootElement` exist, and if not, `getClassNames` will return an empty array (non initialised `wuiDom` have no class)
