### PR TITLE
Fix/toggle display

### DIFF
--- a/index.js
+++ b/index.js
@@ -747,7 +747,7 @@ WuiDom.prototype.toggleDisplay = function (shouldShow) {
 	} else {
 		this.hide();
 	}
-	return shouldShow;
+	return !!shouldShow;
 };
 
 /**


### PR DESCRIPTION
My problem is as follow.
I have the following component with a method `toggle`:

``` javascript
function MapCoordinateDisplay() {
    WuiDom.call(this, 'div', { className: 'mapCoordinateDisplay' });
    // more code here
}
inherits(MapCoordinateDisplay, WuiDom);

MapCoordinateDisplay.prototype.toggle = function (value) {
    this.toggleDisplay(value);
    return this.isVisible();
};
```

When doing:

``` javascript
mapCoordinateDisplay.toggle();
```

I would expect `WuiDom` to `toggleDisplay()`, but as an `undefined` argument is provided, `WuiDom` will alway `show()`

To correct this, I propose to consider that an `undefined` argument is the same as no arguments.
