### PR TITLE
New method WuiDom#getChildCount

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -332,6 +332,13 @@ WuiDom.prototype.getChildren = function () {
 };
 
 /**
+ * @returns {number} - Number of children attached to this WuiDom
+ */
+WuiDom.prototype.getChildCount = function () {
+	return this._childrenList.length;
+};
+
+/**
  * @param {string} childName
  * @returns {WuiDom|undefined}
  */


### PR DESCRIPTION
`WuiDom#getChildCount()` is just a fast way to know how many children are there - without making a copy of the array that will be GC'ed right away.

It can be used instead of `myWuiDom.getChildren().length`

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/wizui/wuidom/53)

<!-- Reviewable:end -->
